### PR TITLE
Add manual DB update route

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -48,6 +48,10 @@
     <button onclick="(()=>{
         fetch('/resetSelectCount');
     })()">Reset Select Count</button><br /><br />
+
+    <label for="manualData">Manual DB Update JSON:</label><br />
+    <textarea id="manualData" rows="10" cols="80"></textarea><br />
+    <button onclick="submitManualData()">Submit Update Data</button><br /><br />
     <label>MJ / Discord login - </label>
     <label for="username">Discord Username:</label>
     <input type="text" id="username" name="username" value="">
@@ -130,6 +134,17 @@
                         // loggerText.scrollTop = loggerText.scrollHeight;
                     }
                 });
+        }
+
+        function submitManualData() {
+            let text = document.getElementById('manualData').value;
+            let json;
+            try { json = JSON.parse(text); } catch (e) { alert('Invalid JSON'); return; }
+            fetch('/updateDB_data', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(json)
+            });
         }
 
         getLogsFromServer();


### PR DESCRIPTION
## Summary
- add JSON text area to home page to submit manual DB updates
- implement `DatabaseUpdateManualData` for processing pasted JSON
- create `/updateDB_data` route to accept manual image data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b7d6f89b4832d84056c21f26b9e96